### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='lime_stability',
-    version='0.1.1',
+    version='0.1.2',
     author="Giorgio Visani",
     author_email="giorgio.visani2@unibo.it",
     description="A package to evaluate Lime stability",

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
         'lime',
         'statsmodels',
         'statistics',
-        'numpy',
-        'scikit-learn>=0.18'
+        'numpy==1.26.4',
+        'scikit-learn==1.1.3'
     ],
     license='BSD',
     zip_safe=False)


### PR DESCRIPTION
Fix dependency issues.
+ numpy dtype size was changed so it was producing issues.
+ scikit-learn the `load_boston` was removed from the package in its newer versions.